### PR TITLE
add more step-by-step instructions to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,45 @@
 This are the source files for our trainings. For the builded versions, see:
 https://docs.adfinis-sygroup.ch/public/trainings
 
+
+## How to clone the git repository
+
+For read-write clone it over ssh
+
+    git clone --recursive git@github.com:adfinis-sygroup/adsy-trainings.git
+
+or for read-only over https
+
+    git clone --recursive https://github.com/adfinis-sygroup/adsy-trainings.git
+
+
 ## How to create a new training
 
-- Copy the directory `skeleton` to your training name
- - All trainings need to be in the following directory structure:
-  `training-name/module-name/`
+Each training has three unique parts
 
-- Edit `training-name/module-name/*yml` to your needs. This file is required to build the training.
+- Name of the training
+- Name of the module
+- A unique ID
+
+    $ ./adsy-trainings-common.src/new-training.sh <training name> <module name> <id>
+
+- Edit `<training-name>/<id>_<module-name>/modul_<module-name>_<id>.yml` to
+  your needs. This file is required to build the training.
+
 - Add your training content
-  - All images needs to be in a subdirectory of `training-name/module-name/`,
-  eg.  `training-name/module-name/static`. Otherwise they will not display when builded
-  - Make sure to only use non-copyrighted materials
 
-- Add the files to the git repository and push it. After a few minutes, the new training should be available at https://docs.adfinis-sygroup.ch/public/trainings
+    - All images need to be in a subdirectory of
+      `<training-name>/<id>_<module-name>/`,
+      e.g. `<training-name>/<id>_<module-name>/`, otherwise they will not be
+      displayed when built
+
+    - Make sure to only use non-copyrighted materials
+
+- Check if your training looks like you wish.
+
+    cd <training-name>/<id>_<module-name>/
+    make
+
+- Add the files to the git repository and push it. After a few minutes, the
+  new training should be available at
+  https://docs.adfinis-sygroup.ch/public/trainings


### PR DESCRIPTION
I added a bash script to build the environment of a new training from skeleton. I know only a few steps are needed, but it was requested as a feature.