### PR TITLE
Add .git to .dockerignore example

### DIFF
--- a/docker-workshop/2002_dockerfile/modul_dockerfile_2002_01_slides.md
+++ b/docker-workshop/2002_dockerfile/modul_dockerfile_2002_01_slides.md
@@ -52,6 +52,8 @@ To exclude specific files create a **.dockerignore** file
 README.md
 # exclude *.pyc files
 **/*.pyc
+# exclude .git directory
+.git/
 ```
 
 ## Which commands are available?


### PR DESCRIPTION
Having the .git folder in the build context only makes sense in the
rarest of all occasions. Usually removing it from the context makes
a large difference in the size of the context.