### PR TITLE
Fix errors with LABEL command in Dockerfile

### DIFF
--- a/docker-workshop/2002_dockerfile/modul_dockerfile_2002_01_slides.md
+++ b/docker-workshop/2002_dockerfile/modul_dockerfile_2002_01_slides.md
@@ -16,9 +16,10 @@ Each command creates a layer in the image
 
 ```dockerfile
 FROM centos:7
-LABEL maintainer "foo.bar@example.com"
-LABEL maintainer.name "Foo Bar"
-LABEL maintainer.email "foo.bar@example.com"
+LABEL maintainer="foo.bar@example.com"
+LABEL maintainer.name="Foo Bar"
+LABEL maintainer.email="foo.bar@example.com"
+LABEL com.example.version="0.0.2"
 
 RUN yum install -y \
       curl \
@@ -73,10 +74,10 @@ FROM centos:7
 Add metadata to your Docker image
 
 ```dockerfile
-LABEL maintainer "foo.bar@example.com"
-LABEL maintainer.name "Foo Bar"
-LABEL maintainer.email "foo.bar@example.com"
-LABEL version="0.9"
+LABEL maintainer="foo.bar@example.com"
+LABEL maintainer.name="Foo Bar"
+LABEL maintainer.email="foo.bar@example.com"
+LABEL com.example.version="0.9"
 LABEL desc="Even text spanning \
 multiple lines is possible"
 ```

--- a/docker-workshop/2002_dockerfile/modul_dockerfile_2002_03_handson.md
+++ b/docker-workshop/2002_dockerfile/modul_dockerfile_2002_03_handson.md
@@ -24,9 +24,10 @@ Build a Docker image **nginx:demo** with these instructions:
 Dockerfile
 ```dockerfile
 FROM nginx:stable
-LABEL maintainer "lukas.grossar@adfinis-sygroup.ch"
-LABEL maintainer.name "Lukas Grossar"
-LABEL maintainer.email "lukas.grossar@adfinis-sygroup.ch"
+LABEL maintainer="foo.bar@example.com"
+LABEL maintainer.name="Foo Bar"
+LABEL maintainer.email="foo.bar@example.com"
+LABEL com.example.version="0.0.1"
 
 COPY index.html /usr/share/nginx/html/
 ```


### PR DESCRIPTION
In a LABEL command key and value needs can't be separated by a space, so we've replaced the spaces with equals signs.