### PR TITLE
only trigger Gitlab CI on master branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,3 +25,5 @@ docs:
   artifacts:
     paths:
       - trainings/*
+  only:
+    - master


### PR DESCRIPTION
This avoid issues where a push to a branch might overwrite already
published data on https://docs.adfinis-sygroup.ch/public/trainings