### PR TITLE
split docs building into two stages

### DIFF
--- a/.docs-bot.yml
+++ b/.docs-bot.yml
@@ -2,4 +2,4 @@ docs:
   extract_to: /var/www/html/public
   download_delay: 15
   stages:
-    - docs
+    - publish-docs

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,10 +8,11 @@ before_script:
 image: eni23/adsy-training-builder:v3
 
 stages:
-  - docs
+  - build-docs
+  - publish-docs
 
-docs:
-  stage: docs
+build-docs:
+  stage: build-docs
   script:
     - sed "s/git@github.com:adfinis-sygroup\/adsy-trainings-common.git/https:\/\/github.com\/adfinis-sygroup\/adsy-trainings-common.git/g" -i .gitmodules
     - git submodule sync
@@ -21,6 +22,13 @@ docs:
     - git submodule update
     - mkdir build
     - adsy-trainings-common.src/training-builder.py --root=. --commons=adsy-trainings-common.src --build-dir=build
+  artifacts:
+    paths:
+      - build/*
+
+publish-docs:
+  stage: publish-docs
+  script:
     - mv build trainings
   artifacts:
     paths:


### PR DESCRIPTION
- build-docs runs on every branch, to ensure that we see build failures
- publish-docs is only run on master and triggers docs-bot