### PR TITLE
[Makefile] Target for building individual trainings

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,8 +19,7 @@ build-docs:
     - cat .git/config
     - git submodule init
     - git submodule update
-    - mkdir build
-    - adsy-trainings-common.src/training-builder.py --root=. --commons=adsy-trainings-common.src --build-dir=build --ignore=skeleton
+    - make build
   artifacts:
     paths:
       - build/*

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,36 @@
-TRAINING_BUILDER=adsy-trainings-common.src/training-builder.py
+TRAINING_COMMONS=adsy-trainings-common.src
+TRAINING_BUILDER=$(TRAINING_COMMONS)/training-builder.py
+TRAINING_ARGS= --root=. --commons=$(TRAINING_COMMONS) --build-dir=build
 
-all:
-	$(TRAINING_BUILDER) --root=. --commons=adsy-trainings-common.src --build-dir=build --ignore=skeleton
+.PHONY: all build index help training-%
 
-index:
-	$(TRAINING_BUILDER) --root=. --commons=adsy-trainings-common.src --build-dir=build --index-only
+all: help
+
+help:  ## Display this help.
+	@echo " Adfinis-Sygroup AG - Training Builder"
+	@echo
+	@echo " Build targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+		| sort -k 1,1 \
+		| awk 'BEGIN {FS = ":.*?## "}; {printf "  * \033[36m%-6s\033[0m %s\n", $$1, $$2}'
+	@echo
+	@echo " Available training build targets:"
+	@find -mindepth '1' -maxdepth '1' -type d \
+	    -not -name 'skeleton' \
+	    -not -name '.git' \
+	    -not -name 'build' \
+	    -not -name 'adsy-trainings-common.src' \
+	    -printf '  * \033[36mtraining-%f\033[0m\n' \
+	    | sort -k 1,1
+	@echo
+
+build: ## Build all trainings.
+	$(TRAINING_BUILDER) $(TRAINING_ARGS) --ignore=skeleton
+
+index: ## Build training index page.
+	$(TRAINING_BUILDER) $(TRAINING_ARGS) --index-only
+
+training-%: ## Build an individual training.
+	$(TRAINING_BUILDER) $(TRAINING_ARGS) --only=$(subst training-,,$@)
+
+


### PR DESCRIPTION
This allows building individual trainings and adds some help output to the makefile:

```
$ make
 Adfinis-Sygroup AG - Training Builder

 Build targets:
  * build  Build all trainings.
  * help   Display this help.
  * index  Build training index page.

 Available training build targets:
  * training-ansible-workshop
  * training-docker-workshop
  * training-foreman-workshop
  * training-git-gitlab-workshop
  * training-kubernetes-workshop
  * training-openshift-workshop
  * training-suma-workshop
  * training-suse-system-administration
  * training-terraform-workshop
  * training-test
```

You can now call ie. `make training-openshift-workshop` to rebuild just the openshift-workshop.