### PR TITLE
:bug: fix build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,8 @@ build-docs:
     - cat .git/config
     - git submodule init
     - git submodule update
-    - make build
+    - mkdir build
+    - adsy-trainings-common.src/training-builder.py --root=. --commons=adsy-trainings-common.src --build-dir=build --ignore=skeleton
   artifacts:
     paths:
       - build/*


### PR DESCRIPTION
Doesn't depend on make inside the build container.

This reverts parts of 6ac7f9fa7274c605f14bd031af5d6464df15a13e since the change to the gitlab runner config broke our build.

The proper solution would be to update the `eni23/adsy-training-builder:v3` which is based on a oldish arch linux with a extremly specific version of wkhtmltopdf.

I gave migrating all of this to something like a modern arch or even debian:slim a try but utterly failed to do so. It looks like it might make more sense to just refactor the pdf generation to something like weasyprint. Personally I've never used the PDF versions and I'm not 100% convinced that we really need them.