### PR TITLE
Remove ReplicationController from Kubernetes workshop

### DIFF
--- a/kubernetes-workshop/6001_basics/modul_basics_6001_01_slides.md
+++ b/kubernetes-workshop/6001_basics/modul_basics_6001_01_slides.md
@@ -96,7 +96,7 @@ Ingress allows external access to Services
 * TCP/UDP support in the future
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: "echo-ingress"

--- a/kubernetes-workshop/6001_basics/modul_basics_6001_01_slides.md
+++ b/kubernetes-workshop/6001_basics/modul_basics_6001_01_slides.md
@@ -82,6 +82,7 @@ spec:
     env: "production"
   ports:
     - protocol: "TCP"
+      name: http
       port: 80
       targetPort: 8080
 ```
@@ -103,7 +104,7 @@ metadata:
 spec:
   backend:
     serviceName: "echoheaders"
-    servicePort: 80
+    servicePort: http
   tls:
     - hosts:
       - "echo.example.com"

--- a/kubernetes-workshop/6001_basics/modul_basics_6001_01_slides.md
+++ b/kubernetes-workshop/6001_basics/modul_basics_6001_01_slides.md
@@ -168,7 +168,7 @@ List Kubernetes resources
 ```bash
 kubectl get all
 kubectl get pods
-kubectl get dc
+kubectl get deploy
 kubectl get pods -o wide
 kubectl get all -l env=production
 kubectl get po/nodejs-ex -o yaml
@@ -182,7 +182,7 @@ Edit resource definitions
 * Suitable for debugging
 
 ```bash
-kubectl edit dc/nodejs-ex
+kubectl edit deploy/nodejs-ex
 ```
 
 ## kubectl delete
@@ -190,5 +190,5 @@ kubectl edit dc/nodejs-ex
 Deletion of resources
 
 ```bash
-kubectl delete rc/nodejs-ex
+kubectl delete deploy/nodejs-ex
 ```


### PR DESCRIPTION
Nobody should use that API anyway.